### PR TITLE
Prepare v0.5.4 main release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This project is licensed under the **Business Source License 1.1 (BSL 1.1)**. It
 
 ### Current BETA release
 
-`v0.5.00` is published as the current **BETA main-channel release**:
+`v0.5.4` is published as the current **BETA main-channel update release**:
 
-- Release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
-- Raspberry Pi image: `5tratumos-raspios-lite-v0.5.00.img.xz`
-- UEFI installer ISO: `5tratumos-installer-v0.5.00-uefi.iso`
-- BIOS installer ISO: `5tratumos-installer-v0.5.00-bios.iso`
-- Update bundle: `5tratumos-update-v0.5.00.tgz`
+- Release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.4
+- Update bundle: `5tratumos-update-v0.5.4.tgz`
+
+Fresh-install media remains under `v0.5.00`. After installation, use the main
+update channel to move to `v0.5.4`.
 
 Use `Settings -> Updates` and select the **main** channel to pick up this release on an existing install.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,8 @@ This repo publishes 5tratumOS **release artifacts** via GitHub Releases.
 
 Release/navigation shortcuts:
 
-- Current BETA release: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.00`
+- Current BETA main-channel update: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.4`
+- Current BETA install media: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.00`
 - Latest main-channel release: `https://github.com/WillItMod/5tratum/releases/latest`
 - Full release history: `https://github.com/WillItMod/5tratum/releases`
 - Repo tags: `https://github.com/WillItMod/5tratum/tags`

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,7 +2,8 @@
 
 5tratumOS is distributed via **GitHub Releases** (update bundles + install media). Not every tag includes every asset, so use the Releases page to find the newest installer media.
 
-- Current BETA release: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
+- Current BETA main-channel update: https://github.com/WillItMod/5tratum/releases/tag/v0.5.4
+- Current BETA installer media: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
 - Latest main-channel release: https://github.com/WillItMod/5tratum/releases/latest
 - Full release history: https://github.com/WillItMod/5tratum/releases
 

--- a/docs/rpi/README.md
+++ b/docs/rpi/README.md
@@ -54,8 +54,8 @@ Example:
 ssh -t pi@192.168.1.50 "curl -fsSL https://raw.githubusercontent.com/WillItMod/5tratum/main/scripts/install-rpi.sh -o /tmp/install-rpi.sh && sudo env CHANNEL=main bash /tmp/install-rpi.sh"
 ```
 
-The bootstrap installer defaults to the current BETA main-channel bundle:
-`v0.5.00`.
+The bootstrap installer follows the current BETA main-channel bundle, presently
+`v0.5.4`.
 
 ## First boot
 


### PR DESCRIPTION
Promotes the tested v0.5.4-dev payload to the main update channel.\n\nUpdates the public release documentation to identify v0.5.4 as the current main-channel update while retaining v0.5.00 as the current fresh-install media.\n\nValidation: the promoted bundle differs from v0.5.4-dev only in embedded build metadata; both checksum sidecars pass.