### PR TITLE
Point fresh installs to full OS images

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,26 @@ This project is licensed under the **Business Source License 1.1 (BSL 1.1)**. It
 
 ### Current BETA release
 
-`v0.5.4` is published as the current **BETA main-channel update release**:
+`v0.5.8` is published as the current **BETA main-channel update release**:
 
-- Release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.4
-- Update bundle: `5tratumos-update-v0.5.4.tgz`
+- Release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.8
+- Update bundle for existing installations: `5tratumos-update-v0.5.8.tgz`
 
 Fresh-install media remains under `v0.5.00`. After installation, use the main
-update channel to move to `v0.5.4`.
+update channel to move to `v0.5.8`.
 
 Use `Settings -> Updates` and select the **main** channel to pick up this release on an existing install.
 
 ### OS update bundle (existing installs)
 
 - Updates are delivered via the WebUI: `Settings -> Updates -> Check updates`.
-- Latest main-channel release: https://github.com/WillItMod/5tratum/releases/latest
+- Latest existing-install update: https://github.com/WillItMod/5tratum/releases/latest
 - Full release history: https://github.com/WillItMod/5tratum/releases
 - Repo tags: https://github.com/WillItMod/5tratum/tags
 
 Notes:
 - Use the **Releases** page for published update bundles and installer assets.
-- Main-channel systems follow the latest non-prerelease release.
+- Main-channel systems follow the latest non-prerelease update bundle.
 - Dev-channel systems follow pre-releases/dev builds.
 - The latest tag, latest dev pre-release, and latest main-channel release are not always the same thing.
 
@@ -49,16 +49,19 @@ Installer ISOs and Raspberry Pi images are not attached to every release tag. If
 
 - **Published assets live on the Releases page**
   - Current BETA media release: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
-  - Latest main-channel release: https://github.com/WillItMod/5tratum/releases/latest
   - All releases: https://github.com/WillItMod/5tratum/releases
 - **AMD/Intel installer ISO**
-  - Download the newest release that includes:
-    - `5tratumos-installer-<version>-uefi.iso`
-    - `5tratumos-installer-<version>-bios.iso`
+  - UEFI ISO: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-uefi.iso
+  - UEFI checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-uefi.iso.sha256
+  - Legacy BIOS ISO: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-bios.iso
+  - Legacy BIOS checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-bios.iso.sha256
 - **Raspberry Pi (arm64) image**
-  - Download the newest release that includes:
-    - `5tratumos-raspios-lite-<version>.img.xz`
-    - the matching `.sha256`
+  - Image: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz
+  - Checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz.sha256
+
+The installer links above are complete bootable images. The `.tgz` assets in
+newer releases are updater payloads for an existing 5tratumOS system and are not
+fresh-install media.
 
 ## Related Projects
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,19 +4,21 @@ This repo publishes 5tratumOS **release artifacts** via GitHub Releases.
 
 Release/navigation shortcuts:
 
-- Current BETA main-channel update: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.4`
+- Current BETA main-channel update: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.8`
 - Current BETA install media: `https://github.com/WillItMod/5tratum/releases/tag/v0.5.00`
-- Latest main-channel release: `https://github.com/WillItMod/5tratum/releases/latest`
+- Latest existing-install update: `https://github.com/WillItMod/5tratum/releases/latest`
 - Full release history: `https://github.com/WillItMod/5tratum/releases`
 - Repo tags: `https://github.com/WillItMod/5tratum/tags`
 
 Notes:
 
 - Use the **Releases** page for published update bundles and installer assets.
-- Main-channel systems follow the latest non-prerelease release.
+- Main-channel systems follow the latest non-prerelease update bundle.
 - Dev-channel systems follow pre-releases/dev builds.
 - Use the **Tags** page when you need to inspect newer tag flow that may not yet be represented as a published release entry.
 - The README release banner is documentation, not the authoritative live source of truth.
+- Fresh installs use the full v0.5.00 UEFI ISO, BIOS ISO or Raspberry Pi image.
+  The current main-channel updater then moves the installation to v0.5.8.
 
 - Install: [install/README.md](install/README.md)
 - Firmware (BIOS/UEFI/Secure Boot): [install/FIRMWARE.md](install/FIRMWARE.md)

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,9 +2,8 @@
 
 5tratumOS is distributed via **GitHub Releases** (update bundles + install media). Not every tag includes every asset, so use the Releases page to find the newest installer media.
 
-- Current BETA main-channel update: https://github.com/WillItMod/5tratum/releases/tag/v0.5.4
+- Current BETA main-channel update: https://github.com/WillItMod/5tratum/releases/tag/v0.5.8
 - Current BETA installer media: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
-- Latest main-channel release: https://github.com/WillItMod/5tratum/releases/latest
 - Full release history: https://github.com/WillItMod/5tratum/releases
 
 ## Requirements
@@ -20,17 +19,16 @@ Raspberry Pi uses a separate arm64 image. See [Raspberry Pi install](../rpi/READ
 
 ## Get the installer ISO (x86_64 / amd64)
 
-1) Open the releases page:
-- https://github.com/WillItMod/5tratum/releases
+Download the current complete image directly:
 
-2) Download the newest asset that matches:
-- `5tratumos-installer-v<version>-uefi.iso` (recommended)
-- `5tratumos-installer-v<version>-bios.iso` (legacy BIOS/CSM only)
-- matching `.sha256`
+- UEFI ISO: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-uefi.iso
+- UEFI checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-uefi.iso.sha256
+- Legacy BIOS ISO: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-bios.iso
+- Legacy BIOS checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-installer-v0.5.00-bios.iso.sha256
 
-At the time of writing, the newest BETA installer ISOs are under tag **v0.5.00**.
-
-Note: release asset filenames are versioned (for example, `5tratumos-installer-v0.5.00-uefi.iso`).
+The newest complete BETA installer media is v0.5.00. After first boot, use
+`Settings -> Updates` to move to the current v0.5.8 main-channel release.
+Newer `.tgz` assets are updater payloads, not bootable installers.
 
 ## Downloads (per release)
 
@@ -46,6 +44,8 @@ Releases include:
 2) **Raspberry Pi image (arm64)** (when published)
    - Filename: `5tratumos-raspios-lite-v<version>.img.xz`
    - Purpose: flash directly to microSD/SSD, then boot on a Raspberry Pi 4/5.
+   - Current image: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz
+   - Checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz.sha256
 
 If you're installing on AMD/Intel hardware and are unsure, use the **UEFI installer ISO**.
 

--- a/docs/rpi/README.md
+++ b/docs/rpi/README.md
@@ -12,13 +12,11 @@ This guide is for the **Raspberry Pi image** distributed in GitHub Releases.
 
 ## Download
 
-From the release assets:
+Current full BETA image:
 
-- `5tratumos-raspios-lite-v<version>.img.xz`
-- `5tratumos-raspios-lite-v<version>.img.xz.sha256`
-
-Current BETA release:
-- https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
+- Image: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz
+- Checksum: https://github.com/WillItMod/5tratum/releases/download/v0.5.00/5tratumos-raspios-lite-v0.5.00.img.xz.sha256
+- Release notes: https://github.com/WillItMod/5tratum/releases/tag/v0.5.00
 
 All releases:
 - https://github.com/WillItMod/5tratum/releases
@@ -55,7 +53,7 @@ ssh -t pi@192.168.1.50 "curl -fsSL https://raw.githubusercontent.com/WillItMod/5
 ```
 
 The bootstrap installer follows the current BETA main-channel bundle, presently
-`v0.5.4`.
+`v0.5.8`.
 
 ## First boot
 


### PR DESCRIPTION
## Summary\n- distinguish bootable fresh-install media from updater bundles\n- link the v0.5.00 UEFI ISO, BIOS ISO and Raspberry Pi image directly\n- identify v0.5.8 as the current post-install updater\n\n## Validation\n- verified all release assets in GitHub Releases\n- checked documentation links and diff formatting