### PR TITLE
Document v0.5.9 app routing hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.5.9 and v0.5.9-dev (2026-07-24)
+
+- Fix app windows being routed to a node JSON-RPC port while the real web UI is
+  still starting after an install or update.
+- Treat the UI port declared by an app store manifest as authoritative.
+- Reject the Bitcoin-derived `JSONRPC server handles only POST requests`
+  response during web UI detection.
+- Repair affected 5tratSmack routes back to port `21226`; its node RPC remains
+  isolated on `57576`.
+- Release the same routing correction to both MAIN and DEV.
+
 Legend:
 - `*-dev` = DEV-only pre-release
 - MAIN = non-pre-release and/or `releases/latest`

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Full media release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.
 ### Existing installation: update in the WebUI
 
 After first boot, use `Settings -> Updates`, select the **main** channel and
-update to **v0.5.8**.
+update to **v0.5.9**.
 
-- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.5.8
-- Existing-install updater: `5tratumos-update-v0.5.8.tgz`
+- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.5.9
+- Existing-install updater: `5tratumos-update-v0.5.9.tgz`
 
 The `.tgz` file is deliberately not presented as a fresh-install download. It
 is an updater payload for an already running 5tratumOS system.


### PR DESCRIPTION
## What changed

- Sets v0.5.9 as the current existing-install update.
- Documents the app UI versus JSON-RPC routing correction for MAIN and DEV.
- Records the authoritative 5tratSmack UI and RPC ports.

## Validation

The locally built v0.5.9 and v0.5.9-dev bundles contain the corrected daemon and matching channel metadata.