### PR TITLE
Publish 5tratumOS 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.6.0 (2026-07-27)
+
+- Add 5tratMux as a native 5tratumOS control surface beneath Fleet Dashboard.
+- Bootstrap the independently signed 5tratMux updater without starting a trial.
+- Support production 5tratMux runtimes for both AMD64 and ARM64 systems.
+- Reconcile proxy-routed miners by physical identity so Fleet Dashboard reports
+  one current row per miner instead of stale per-pool duplicates.
+- Prefer current Mux telemetry for route, worker, hardware, and hashrate state
+  while preserving direct-pool operation for users who do not run 5tratMux.
+- Add Mux-aware app control, route health, and full hardware telemetry,
+  including normalized temperature, fan, power, frequency, efficiency, pool,
+  and freshness fields.
+- Keep 5tratMux updates independent from OS updates while rolling the matching
+  updater and bootstrap service into the OS release.
+- Repair app proxy routes immediately after an OS update.
+
 ## v0.5.9 and v0.5.9-dev (2026-07-24)
 
 - Fix app windows being routed to a node JSON-RPC port while the real web UI is

--- a/README.md
+++ b/README.md
@@ -33,13 +33,18 @@ Full media release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.
 ### Existing installation: update in the WebUI
 
 After first boot, use `Settings -> Updates`, select the **main** channel and
-update to **v0.5.9**.
+update to **v0.6.0**.
 
-- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.5.9
-- Existing-install updater: `5tratumos-update-v0.5.9.tgz`
+- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.6.0
+- Existing-install updater: `5tratumos-update-v0.6.0.tgz`
 
 The `.tgz` file is deliberately not presented as a fresh-install download. It
 is an updater payload for an already running 5tratumOS system.
+
+Version `v0.6.0` introduces the native 5tratMux control surface and its
+independently signed updater. 5tratMux ships architecture-specific AMD64 and
+ARM64 runtimes; installing or updating it does not start its 24-hour trial.
+The trial begins only when the user explicitly activates it inside 5tratMux.
 
 Full release history: https://github.com/WillItMod/5tratum/releases
 

--- a/scripts/install-rpi.sh
+++ b/scripts/install-rpi.sh
@@ -239,16 +239,34 @@ fi
 if [ -f "${stage}/bin/5tratumos" ]; then
   install -m 0755 "${stage}/bin/5tratumos" /usr/local/bin/5tratumos
 fi
+if [ -f "${stage}/bin/5tratmux-update" ]; then
+  install -m 0755 "${stage}/bin/5tratmux-update" /usr/local/sbin/5tratmux-update
+fi
 
-for unit in 5tratumosd.service 5tratumos-overlay.service 5tratumos-firstboot.service 5tratumos-firstboot-update.service; do
-  install -m 0644 "${stage}/systemd/${unit}" "/etc/systemd/system/${unit}"
+units=()
+for unit in \
+  5tratumosd.service \
+  5tratumos-overlay.service \
+  5tratumos-firstboot.service \
+  5tratumos-firstboot-update.service \
+  5tratmux-bootstrap.service
+do
+  if [ -f "${stage}/systemd/${unit}" ]; then
+    install -m 0644 "${stage}/systemd/${unit}" "/etc/systemd/system/${unit}"
+    units+=("${unit}")
+  fi
 done
 
 systemctl daemon-reload || true
-systemctl enable 5tratumosd.service 5tratumos-overlay.service 5tratumos-firstboot.service 5tratumos-firstboot-update.service || true
+if [ "${#units[@]}" -gt 0 ]; then
+  systemctl enable "${units[@]}" || true
+fi
 systemctl start 5tratumos-firstboot.service || true
 systemctl restart 5tratumosd.service || true
 systemctl restart 5tratumos-overlay.service || true
+if [ -f /etc/systemd/system/5tratmux-bootstrap.service ]; then
+  systemctl start 5tratmux-bootstrap.service || true
+fi
 
 echo "[6/6] Done."
 echo "UI: http://<device-ip>/"


### PR DESCRIPTION
## Summary
- document the native 5tratMux integration and independent signed updater
- install and bootstrap 5tratMux on Linux/Ubuntu existing installations
- publish the 0.6.0 update path for AMD64 and ARM64 systems

## Verification
- clean upgrade passed on the test node
- real upgrade passed on 10.10.10.235
- 32 OS integration tests passed
- 152 Mux tests passed
- signed AMD64 and ARM64 Mux runtimes passed source-free and runtime checks