### PR TITLE
Document 5tratumOS 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.6.1 (2026-07-27)
+
+- Repair the normal WebUI update path so the signed 5tratMux runtime is
+  installed and started on clean public systems.
+- Replace the blank connection-refused pane with a branded loading, repair,
+  and retry surface.
+- Correct the Mux bootstrap systemd condition and retry failed initial
+  installs without user intervention.
+- Add a persistent API-health watchdog in addition to Docker's container
+  restart policy.
+- Restart an unhealthy Mux service automatically and use a rate-limited signed
+  reinstall only when a restart cannot restore health.
+- Preserve Mux settings, licence state, trial state, and application data
+  throughout bootstrap and repair.
+
 ## v0.6.0 (2026-07-27)
 
 - Add 5tratMux as a native 5tratumOS control surface beneath Fleet Dashboard.

--- a/README.md
+++ b/README.md
@@ -33,18 +33,20 @@ Full media release page: https://github.com/WillItMod/5tratum/releases/tag/v0.5.
 ### Existing installation: update in the WebUI
 
 After first boot, use `Settings -> Updates`, select the **main** channel and
-update to **v0.6.0**.
+update to **v0.6.1**.
 
-- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.6.0
-- Existing-install updater: `5tratumos-update-v0.6.0.tgz`
+- Current update release: https://github.com/WillItMod/5tratum/releases/tag/v0.6.1
+- Existing-install updater: `5tratumos-update-v0.6.1.tgz`
 
 The `.tgz` file is deliberately not presented as a fresh-install download. It
 is an updater payload for an already running 5tratumOS system.
 
-Version `v0.6.0` introduces the native 5tratMux control surface and its
+Version `v0.6.0` introduced the native 5tratMux control surface and its
 independently signed updater. 5tratMux ships architecture-specific AMD64 and
 ARM64 runtimes; installing or updating it does not start its 24-hour trial.
 The trial begins only when the user explicitly activates it inside 5tratMux.
+Version `v0.6.1` repairs the first-run bootstrap path used by normal WebUI
+updates and adds continuous service-health supervision.
 
 Full release history: https://github.com/WillItMod/5tratum/releases
 


### PR DESCRIPTION
## What changed

- mark v0.6.1 as the current WebUI update
- document the repaired Mux bootstrap path
- document the new service watchdog and signed repair fallback
- clarify that settings, licence, trial, and application state are preserved

## Validation

The matching private build passed 32 integration tests and recovered a deliberately stopped Mux runtime on an isolated Proxmox clone.