### PR TITLE
Add Proxmox LXC installer

### DIFF
--- a/docs/install/PROXMOX.md
+++ b/docs/install/PROXMOX.md
@@ -1,0 +1,108 @@
+# Install 5tratumOS in a Proxmox LXC
+
+The Proxmox helper creates a dedicated **unprivileged Debian LXC** and installs
+5tratumOS inside that guest. It may download the selected Debian template into
+Proxmox storage, but it does not install Docker, nodes, miners or 5tratumOS
+services on the Proxmox VE host.
+
+## Quick start
+
+Open the Proxmox shell, or connect to the Proxmox VE host over SSH as `root`,
+then run:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/WillItMod/5tratum/main/scripts/install-proxmox.sh | bash
+```
+
+The default deployment uses:
+
+- the next available VMID
+- hostname `5tratumos`
+- the newest available Debian 12 or Debian 13 template
+- an unprivileged LXC with nesting, keyctl and FUSE enabled
+- `vmbr0` with DHCP and the Proxmox firewall enabled
+- 4 CPU cores, 8 GiB RAM, 2 GiB swap and a 128 GiB root disk
+- automatic guest startup with the Proxmox host
+
+The helper selects active LXC storage automatically, downloads the Debian
+template when necessary, creates the guest, and runs the supported Linux
+installer inside it.
+
+## Static address and custom resources
+
+Download the helper before using custom options:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/WillItMod/5tratum/main/scripts/install-proxmox.sh -o /root/install-proxmox.sh
+chmod 700 /root/install-proxmox.sh
+bash /root/install-proxmox.sh \
+  --vmid 180 \
+  --hostname 5tratumos \
+  --storage local-lvm \
+  --bridge vmbr0 \
+  --ip 192.168.1.80/24 \
+  --gateway 192.168.1.1 \
+  --disk-gb 512 \
+  --cores 8 \
+  --memory-mb 16384
+```
+
+Run `bash /root/install-proxmox.sh --help` for every option.
+
+## Requirements
+
+- Proxmox VE with a Debian 12 or Debian 13 LXC template available through
+  `pveam`
+- an active storage target supporting LXC root disks
+- an active template storage target (normally `local`)
+- a Linux bridge (normally `vmbr0`)
+- outbound HTTPS and Debian package-repository access
+- enough storage and memory for the 5tratumOS apps you intend to install
+
+The helper requires at least 2 CPU cores, 4 GiB RAM and a 32 GiB root disk.
+Those validation floors are suitable only for testing the platform. Full-node
+apps generally need substantially more memory and SSD/NVMe storage.
+
+## What runs where
+
+Proxmox VE remains the hypervisor and host operating system. The helper creates
+a Debian guest without changing that host role. Inside the guest, 5tratumOS
+runs above the Debian/Linux foundation as the dashboard, app store, update
+surface and container-management layer.
+
+Docker and application containers run only inside the LXC. The helper enables
+the Proxmox LXC features required for nested containers, sets the guest to
+start automatically, and enables the Proxmox firewall flag on its virtual
+network interface.
+
+## After installation
+
+The helper prints the guest address when DHCP has assigned one. Open:
+
+```text
+http://GUEST_IP/
+```
+
+If no address is printed, check the DHCP lease or run:
+
+```sh
+pct exec VMID -- hostname -I
+```
+
+Use a DHCP reservation or the static-address example if this guest will run
+nodes and mining services.
+
+## Troubleshooting
+
+Inspect the guest without changing it:
+
+```sh
+pct status VMID
+pct config VMID
+pct exec VMID -- systemctl status 5tratumosd.service --no-pager
+pct exec VMID -- journalctl -u 5tratumosd.service -n 100 --no-pager
+```
+
+If guest creation succeeds but installation fails, the helper leaves the LXC
+in place for inspection. It never destroys an existing VM or container, and it
+refuses to reuse an occupied VMID.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -59,7 +59,22 @@ If you're installing on AMD/Intel hardware and are unsure, use the **UEFI instal
   - [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 - After install completes, remove the USB/ISO and reboot into the installed OS.
 
-## Proxmox / VM
+## Proxmox
+
+### Dedicated LXC helper
+
+Run the helper as `root` in the Proxmox VE shell:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/WillItMod/5tratum/main/scripts/install-proxmox.sh | bash
+```
+
+It creates a dedicated unprivileged Debian LXC and installs 5tratumOS inside
+the guest. Docker and 5tratumOS services are not installed on the Proxmox host.
+See the [complete Proxmox LXC guide](PROXMOX.md) for resource, storage,
+networking and static-address options.
+
+### Full virtual machine
 
 1. Create a VM (UEFI recommended).
 2. Attach `5tratumos-installer-v<version>-uefi.iso` as a CD-ROM.

--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly INSTALL_REPOSITORY="WillItMod/5tratum"
+readonly DEFAULT_INSTALL_REF="main"
+
+usage() {
+  cat <<'EOF'
+Usage: bash install-proxmox.sh [options]
+
+Create a dedicated, unprivileged Debian LXC on Proxmox VE and install
+5tratumOS inside it. Docker and 5tratumOS services run only in the guest.
+
+Options:
+  --vmid ID                   Container ID (default: next free ID)
+  --hostname NAME             Guest hostname (default: 5tratumos)
+  --storage NAME              LXC root-disk storage (default: auto-detect)
+  --template-storage NAME     Template storage (default: local)
+  --bridge NAME               Network bridge (default: vmbr0)
+  --ip dhcp|CIDR              Guest IPv4 configuration (default: dhcp)
+  --gateway IP                Gateway for a static address
+  --disk-gb N                 Root-disk size (default: 128)
+  --cores N                   CPU cores (default: 4)
+  --memory-mb N               Memory in MiB (default: 8192)
+  --swap-mb N                 Swap in MiB (default: 2048)
+  --channel NAME              5tratumOS update channel (default: main)
+  --install-tag TAG           Bundle tag or latest (default: latest)
+  -h, --help                  Show this help
+
+The helper prefers the newest Debian 12 or Debian 13 template available for
+the host architecture. Use a dedicated guest and increase disk/memory for
+full-node workloads.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+vmid=""
+guest_hostname="5tratumos"
+root_storage=""
+template_storage="local"
+bridge="vmbr0"
+ip_config="dhcp"
+gateway=""
+disk_gb="128"
+cores="4"
+memory_mb="8192"
+swap_mb="2048"
+channel="main"
+install_tag="latest"
+install_ref="${INSTALL_REF:-$DEFAULT_INSTALL_REF}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vmid) vmid="${2:-}"; shift 2 ;;
+    --hostname) guest_hostname="${2:-}"; shift 2 ;;
+    --storage) root_storage="${2:-}"; shift 2 ;;
+    --template-storage) template_storage="${2:-}"; shift 2 ;;
+    --bridge) bridge="${2:-}"; shift 2 ;;
+    --ip) ip_config="${2:-}"; shift 2 ;;
+    --gateway) gateway="${2:-}"; shift 2 ;;
+    --disk-gb) disk_gb="${2:-}"; shift 2 ;;
+    --cores) cores="${2:-}"; shift 2 ;;
+    --memory-mb) memory_mb="${2:-}"; shift 2 ;;
+    --swap-mb) swap_mb="${2:-}"; shift 2 ;;
+    --channel) channel="${2:-}"; shift 2 ;;
+    --install-tag) install_tag="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ "${EUID:-$(id -u)}" -eq 0 ]] ||
+  die "run this helper as root in the Proxmox VE shell"
+
+for command_name in pveversion pvesh pveam pvesm pct qm curl awk grep sort tail dpkg ip; do
+  command -v "$command_name" >/dev/null 2>&1 ||
+    die "missing required Proxmox command: $command_name"
+done
+
+for integer_value in "$disk_gb" "$cores" "$memory_mb" "$swap_mb"; do
+  [[ "$integer_value" =~ ^[0-9]+$ ]] ||
+    die "disk, core, memory and swap values must be whole numbers"
+done
+(( disk_gb >= 32 )) || die "--disk-gb must be at least 32"
+(( cores >= 2 )) || die "--cores must be at least 2"
+(( memory_mb >= 4096 )) || die "--memory-mb must be at least 4096"
+
+[[ "$guest_hostname" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]{0,62}$ ]] ||
+  die "--hostname is invalid"
+[[ "$channel" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]] ||
+  die "--channel is invalid"
+[[ "$install_tag" == "latest" || "$install_tag" =~ ^v[0-9A-Za-z][0-9A-Za-z._-]*$ ]] ||
+  die "--install-tag is invalid"
+[[ "$install_ref" =~ ^[0-9A-Za-z][0-9A-Za-z._/-]*$ ]] ||
+  die "INSTALL_REF is invalid"
+
+if [[ "$ip_config" != "dhcp" && "$ip_config" != */* ]]; then
+  die "--ip must be dhcp or an IPv4 CIDR such as 192.168.1.80/24"
+fi
+if [[ "$ip_config" == "dhcp" && -n "$gateway" ]]; then
+  die "--gateway is only valid with a static --ip"
+fi
+
+ip link show "$bridge" >/dev/null 2>&1 ||
+  die "network bridge $bridge does not exist"
+
+if [[ -z "$vmid" ]]; then
+  vmid="$(pvesh get /cluster/nextid)"
+fi
+[[ "$vmid" =~ ^[0-9]+$ ]] || die "--vmid must be numeric"
+if pct status "$vmid" >/dev/null 2>&1 || qm status "$vmid" >/dev/null 2>&1; then
+  die "VMID $vmid already exists"
+fi
+
+if [[ -z "$root_storage" ]]; then
+  root_storage_status="$(pvesm status -content rootdir)"
+  for preferred_storage in local-lvm local-zfs local; do
+    if awk -v name="$preferred_storage" \
+      'NR > 1 && $1 == name && $3 == "active" {found=1} END {exit !found}' \
+      <<<"$root_storage_status"; then
+      root_storage="$preferred_storage"
+      break
+    fi
+  done
+  if [[ -z "$root_storage" ]]; then
+    root_storage="$(
+      awk 'NR > 1 && $3 == "active" {print $1; exit}' \
+        <<<"$root_storage_status"
+    )"
+  fi
+fi
+[[ -n "$root_storage" ]] ||
+  die "no active storage supporting LXC root disks was found; use --storage"
+
+if ! pvesm status -content rootdir |
+  awk -v name="$root_storage" \
+    'NR > 1 && $1 == name && $3 == "active" {found=1} END {exit !found}'; then
+  die "storage $root_storage is not active or does not support LXC root disks"
+fi
+if ! pvesm status -content vztmpl |
+  awk -v name="$template_storage" \
+    'NR > 1 && $1 == name && $3 == "active" {found=1} END {exit !found}'; then
+  die "template storage $template_storage is not active or does not support templates"
+fi
+
+host_arch="$(dpkg --print-architecture)"
+case "$host_arch" in
+  amd64) template_arch="amd64" ;;
+  arm64) template_arch="arm64" ;;
+  *) die "unsupported Proxmox host architecture: $host_arch" ;;
+esac
+
+echo "[1/5] Selecting a Debian LXC template..."
+pveam update
+template="$(
+  pveam available --section system |
+    awk -v arch="$template_arch" \
+      '$2 ~ ("^debian-(12|13)-standard_.*_" arch "\\.tar\\.(zst|gz)$") {print $2}' |
+    sort -V |
+    tail -n 1
+)"
+[[ -n "$template" ]] ||
+  die "no Debian 12/13 ${template_arch} LXC template is available"
+
+template_volume="${template_storage}:vztmpl/${template}"
+if ! pveam list "$template_storage" | awk '{print $1}' |
+  grep -Fqx "$template_volume"; then
+  echo "[2/5] Downloading ${template}..."
+  pveam download "$template_storage" "$template"
+else
+  echo "[2/5] Reusing ${template}..."
+fi
+
+net0="name=eth0,bridge=${bridge},ip=${ip_config},firewall=1"
+if [[ "$ip_config" != "dhcp" && -n "$gateway" ]]; then
+  net0="${net0},gw=${gateway}"
+fi
+
+echo "[3/5] Creating unprivileged 5tratumOS CT ${vmid}..."
+pct create "$vmid" "$template_volume" \
+  --hostname "$guest_hostname" \
+  --unprivileged 1 \
+  --features nesting=1,keyctl=1,fuse=1 \
+  --ostype debian \
+  --cores "$cores" \
+  --memory "$memory_mb" \
+  --swap "$swap_mb" \
+  --rootfs "${root_storage}:${disk_gb}" \
+  --net0 "$net0" \
+  --onboot 1 \
+  --start 1 \
+  --tags "5tratumos"
+
+guest_ready=0
+for _ in $(seq 1 60); do
+  if pct exec "$vmid" -- test -e /etc/debian_version 2>/dev/null; then
+    guest_ready=1
+    break
+  fi
+  sleep 2
+done
+(( guest_ready == 1 )) ||
+  die "CT $vmid did not become ready; inspect it with: pct console $vmid"
+
+echo "[4/5] Preparing the Debian guest..."
+pct exec "$vmid" -- bash -lc \
+  "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl"
+
+installer_url="https://raw.githubusercontent.com/${INSTALL_REPOSITORY}/${install_ref}/scripts/install-linux.sh"
+echo "[5/5] Installing 5tratumOS inside CT ${vmid}..."
+pct exec "$vmid" -- env \
+  "CHANNEL=${channel}" \
+  "INSTALL_TAG=${install_tag}" \
+  "INSTALLER_URL=${installer_url}" \
+  bash -lc \
+  'set -Eeuo pipefail
+   installer="$(mktemp)"
+   trap '"'"'rm -f "$installer"'"'"' EXIT
+   curl -fsSL --retry 3 --retry-delay 2 "$INSTALLER_URL" -o "$installer"
+   bash "$installer"'
+
+guest_ip="$(
+  pct exec "$vmid" -- hostname -I 2>/dev/null |
+    awk '{print $1}'
+)"
+
+cat <<EOF
+
+5tratumOS is installed in unprivileged CT ${vmid}.
+Guest:    ${guest_hostname}
+Address:  ${guest_ip:-check the DHCP lease or run: pct exec ${vmid} -- hostname -I}
+Dashboard: http://${guest_ip:-GUEST_IP}/
+
+Proxmox remains the host operating system. The Debian guest supplies the Linux
+kernel userspace, and 5tratumOS runs above it as the dashboard, app-store,
+update and container-management layer.
+EOF


### PR DESCRIPTION
## What changed

- add a first-party `install-proxmox.sh` helper
- create a dedicated unprivileged Debian 12/13 LXC using native Proxmox tools
- install 5tratumOS only inside the guest
- support automatic or explicit VMID, storage, bridge, DHCP/static networking, disk, CPU and memory settings
- add a full Proxmox installation and troubleshooting guide
- retain the existing full-VM installation route

## Why

Proxmox was documented only as a manual VM workflow. The 5tratumOS website now presents Linux, Proxmox and Raspberry Pi as first-class installation routes, so the Proxmox route needs a real, copyable helper with the same operational clarity.

## Validation

- `bash -n scripts/install-proxmox.sh`
- `git diff --check`
- mocked full helper lifecycle: template discovery, storage selection, VMID selection, LXC creation, guest preparation and in-guest installer invocation